### PR TITLE
Add serial device to VM template

### DIFF
--- a/vmsetup.sh
+++ b/vmsetup.sh
@@ -88,6 +88,7 @@ qm set ${TEMPLATE_VMID} --memory 8192 \
 			--ostype l26 \
 			--tablet 0 \
 			--boot c --bootdisk virtio0
+   			--serial0 socket
 
 template_vmcreated=$(date +%Y-%m-%d)
 qm set ${TEMPLATE_VMID} --description "Fedora CoreOS - Template

--- a/vmsetup.sh
+++ b/vmsetup.sh
@@ -87,7 +87,7 @@ qm set ${TEMPLATE_VMID} --memory 8192 \
 			--onboot 1 \
 			--ostype l26 \
 			--tablet 0 \
-			--boot c --bootdisk virtio0
+			--boot c --bootdisk virtio0 \
    			--serial0 socket
 
 template_vmcreated=$(date +%Y-%m-%d)


### PR DESCRIPTION
When I used this repo to generate a FCOS template, I noticed several systemd units were not working after the first reboot.

One of the ones not working was `systemd-vconsole-setup.service`.  It was failing due to being unable to open the `/dev/console` device.

According to [this comment on a systemd issue](https://github.com/systemd/systemd/issues/30501#issuecomment-2095981650), the error is caused by having a kernel argument specifying `console=ttyS0` without having the associated console device.  To resolve it, I simply added the device to the `vmsetup.sh` script.

This change should fix that systemd unit failing on every boot and cleanup the login messages.