### PR TITLE
Fix malformed motd

### DIFF
--- a/fcos-base-tmplt.yaml
+++ b/fcos-base-tmplt.yaml
@@ -8,11 +8,11 @@
           OUT=/etc/console-login-helper-messages/issue.d/22_geco.motd
           
           echo -e "\nWelcome on a server powered by\n" > ${OUT}
-          echo -e '\e[33m Welcome this server >> ${OUT}
-          echo -e '\e[33m By accessing this system, you consent to the following conditions: >> ${OUT}
-          echo -e '\e[33m - This system is for authorized use only. >> ${OUT}
-          echo -e '\e[33m - Any or all uses of this system and all files on this system may be monitored. >> ${OUT}
-          echo -e '\e[33m - Communications using, or data stored on, this system are not private. >> ${OUT}
+          echo -e "\e[33m Welcome this server" >> ${OUT}
+          echo -e "\e[33m By accessing this system, you consent to the following conditions:" >> ${OUT}
+          echo -e "\e[33m - This system is for authorized use only." >> ${OUT}
+          echo -e "\e[33m - Any or all uses of this system and all files on this system may be monitored." >> ${OUT}
+          echo -e "\e[33m - Communications using, or data stored on, this system are not private." >> ${OUT}
           eval "$(grep -E "^(NAME=|VARIANT=)" /etc/os-release)" && echo -e "\e[33mOperating System:\e[0m ${NAME} ${VARIANT}" >> ${OUT}
           eval "$(grep ^OSTREE_VERSION /etc/os-release)" && echo -e "\e[33mVersion:\e[0m ${OSTREE_VERSION}" >> ${OUT}
           echo -e "\e[33mKernel:\e[0m $(uname -r)" >> ${OUT}


### PR DESCRIPTION
When I used this repo to generate a FCOS template, I noticed several systemd units were not working after the first reboot.

One of the ones not working was the `geco-motd.service`, which configures the message of the day.  The error I was seeing was:
```
/usr/local/bin/geco-motd.sh: line 23: unexpected EOF while looking for matching `''
```

This file is generated by `fcos-base-tmplt.yaml`, which has a few missing closing comments in the bash code.  This PR adds the appropriate closing comments and fixes the systemd unit. 