### PR TITLE
Fix migrating VMs between nodes

### DIFF
--- a/hook-fcos.sh
+++ b/hook-fcos.sh
@@ -47,9 +47,8 @@ setup_yq
 if [[ "${phase}" == "pre-start" ]]
 then
 	instance_id="$(qm cloudinit dump ${vmid} meta | ${YQ} - 'instance-id')"
-
 	# same cloudinit config ?
-	[[ -e ${COREOS_FILES_PATH}/${vmid}.id ]] && [[ "x${instance_id}" != "x$(cat ${COREOS_FILES_PATH}/${vmid}.id)" ]]&& {
+	[[ -e ${COREOS_FILES_PATH}/${vmid}.id ]] && [[ -n $instance_id ]] && [[ "x${instance_id}" != "x$(cat ${COREOS_FILES_PATH}/${vmid}.id)" ]]&& {
 		rm -f ${COREOS_FILES_PATH}/${vmid}.ign # cloudinit config change
 	}
 	[[ -e ${COREOS_FILES_PATH}/${vmid}.ign ]]&& exit 0 # already done


### PR DESCRIPTION
When migrating a container to another node, hookscript is run again.  However this time, the `qm cloudinit dump` command can't find the VMID (because it hasn't been created yet).  A bit of a catch22.

This change causes the hook script to skip all cloud init and ignition generation steps when starting on a new system which doesn't yet have the VM definition required for `qm cloudinit dump` to work properly.  It works by essentially just keeping the current ignition config if the instance id fails to resolve to a real, reasonable value.

Net result: working migrations.  Rebooting after a migration will cause the hook script to run normally and could regenerate the ignition file if the instance id of the container has changed.  

Testing has not been thorough with this change yet, but I have had some success running this on my cluster.